### PR TITLE
fix(client): Logo overlay on narrow screens #49985

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -53,6 +53,7 @@
 
 #universal-nav-logo svg {
   margin: 4px;
+  width: 180px;
 }
 
 .nav-list {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Describe the Issue:

When the user uses FreeCodeCamp on narrow screens like the Samsung galaxy fold, the FreeCodeCamp logo overlaps with the drop-down menu button and profile picture at the top of the page. (fixed)

Closes #49985

![imagen_2023-04-12_113723250](https://user-images.githubusercontent.com/72409256/231524155-6f45c235-9a17-4a6f-a6fa-56795b19c215.png)


